### PR TITLE
feat: add audio recording and audio response as feedback

### DIFF
--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Slider } from '@/components/ui/slider';
+import { Microphone } from '@/components/microphone';
 
 const formSchema = z.object({
   name: z
@@ -48,10 +49,7 @@ const InterviewPage = () => {
       <div className='flex flex-col gap-4'>
         <h3 className='font-medium'>Paso 1/2</h3>
         <Slider defaultValue={[50]} max={100} disabled withOutThumb />
-        <p>
-          En este paso, se le harán una serie de preguntas para ayudarle a crear su perfil. Esta información no será
-          compartida con los empleadores.
-        </p>
+        <p>En este paso, se le harán una serie de preguntas para ayudarle a crear su perfil.</p>
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='max-w-[448px] space-y-4'>
@@ -107,6 +105,7 @@ const InterviewPage = () => {
               </FormItem>
             )}
           />
+          <Microphone />
           <Button type='submit'>Enviar</Button>
         </form>
       </Form>

--- a/src/components/microphone.tsx
+++ b/src/components/microphone.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Mic, MicOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { useRecordVoice } from '@/hooks/useRecordVoice';
+
+import { Button } from './ui/button';
+
+const Microphone = () => {
+  const { startRecording, stopRecording } = useRecordVoice();
+  const [isRecording, setIsRecording] = useState(false);
+  const [selectedVoice, setSelectedVoice] = useState<SpeechSynthesisVoice | null>(null);
+  const [synth, setSynth] = useState<SpeechSynthesis | null>(null);
+  const pitch = 0.9;
+  const rate = 1;
+
+  // Function to load available voices
+  const loadVoices = () => {
+    if (synth) {
+      const availableVoices = synth.getVoices();
+      const spanishIndexVoice = availableVoices.findIndex((voice) => voice.name === 'Google español');
+      const voice = availableVoices[spanishIndexVoice];
+      setSelectedVoice(voice || null);
+    }
+  };
+
+  // Start recording with spacebar or enter
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.code === 'Space' || e.code === 'Enter') {
+      e.preventDefault();
+      if (!isRecording) {
+        startRecording();
+        setIsRecording(true);
+      }
+    }
+  };
+
+  // Stop recording when spacebar or enter is released
+  const handleKeyUp = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.code === 'Space' || e.code === 'Enter') {
+      e.preventDefault();
+      if (isRecording) {
+        stopRecording();
+        setIsRecording(false);
+      }
+    }
+  };
+
+  // Audio feedback
+  const giveAudioFeedback = (message: string) => {
+    if (synth) {
+      const utterThis = new SpeechSynthesisUtterance(message);
+      if (selectedVoice) utterThis.voice = selectedVoice;
+      utterThis.pitch = pitch;
+      utterThis.rate = rate;
+      synth.speak(utterThis);
+    }
+  };
+
+  useEffect(() => {
+    if (isRecording) {
+      giveAudioFeedback('Grabación iniciada');
+    } else {
+      giveAudioFeedback('Grabación detenida');
+    }
+  }, [isRecording]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const synthInstance = window.speechSynthesis;
+      setSynth(synthInstance);
+
+      if (synthInstance.onvoiceschanged !== undefined) {
+        synthInstance.onvoiceschanged = loadVoices;
+      } else {
+        loadVoices();
+      }
+    }
+  }, [synth]);
+
+  return (
+    <div>
+      <Button
+        onMouseDown={() => {
+          startRecording();
+          setIsRecording(true);
+        }}
+        onMouseUp={() => {
+          stopRecording();
+          setIsRecording(false);
+        }}
+        onTouchStart={() => {
+          startRecording();
+          setIsRecording(true);
+        }}
+        onTouchEnd={() => {
+          stopRecording();
+          setIsRecording(false);
+        }}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        aria-pressed={isRecording}
+        aria-label='Botón para grabar audio. Presiona y mantén la barra espaciadora para grabar. Suelta para detener.'
+        className='flex items-center gap-2 px-4'
+      >
+        {isRecording ? <Mic size={24} color='#121712' /> : <MicOff size={24} color='#121712' />}
+        Grabar
+      </Button>
+    </div>
+  );
+};
+
+export { Microphone };

--- a/src/hooks/useRecordVoice.ts
+++ b/src/hooks/useRecordVoice.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+
+export const useRecordVoice = () => {
+  const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(null);
+  const [recording, setRecording] = useState<boolean>(false);
+  const chunks = useRef<Blob[]>([]);
+
+  const startRecording = () => {
+    if (mediaRecorder) {
+      mediaRecorder.start();
+      setRecording(true);
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorder) {
+      mediaRecorder.stop();
+      setRecording(false);
+    }
+  };
+
+  const initialMediaRecorder = useCallback((stream: MediaStream) => {
+    const mediaRecorderInstance = new MediaRecorder(stream);
+
+    mediaRecorderInstance.onstart = () => {
+      chunks.current = [];
+    };
+
+    mediaRecorderInstance.ondataavailable = (ev: BlobEvent) => {
+      chunks.current.push(ev.data);
+    };
+
+    mediaRecorderInstance.onstop = () => {
+      const audioBlob = new Blob(chunks.current, { type: 'audio/wav' });
+      // eslint-disable-next-line no-console
+      console.log(audioBlob, 'audioBlob');
+
+      // TODO: send audioBlob to backend
+    };
+
+    setMediaRecorder(() => mediaRecorderInstance);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      navigator.mediaDevices.getUserMedia({ audio: true }).then(initialMediaRecorder);
+    }
+  }, [initialMediaRecorder]);
+
+  return { recording, startRecording, stopRecording };
+};


### PR DESCRIPTION
**Result:**
I have implemented audio recording functionality that can be controlled via the space bar. Pressing and holding the space bar starts recording, and releasing it stops the recording. Additionally, users will receive auditory feedback in both cases to provide clear indications of the recording status.
![image](https://github.com/user-attachments/assets/537f5d70-12e3-4bc3-9521-d9404732b97d)
